### PR TITLE
Go to 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+### 2.28.0
+* Update OTF Regenerate Thumbnails plugin:
+  * Refactor: Enforce strict WordPress Coding Standards (WPCS), including tab indentation, proper spacing, and separating the plugin header from the DocBlock.
+  * Style: Update variable naming conventions from camelCase to snake_case (e.g., $imagePath to $image_path).
+  * Enhancement: Add avif to the list of supported image extensions for modern WordPress compatibility.
+  * Refactor: Replace native PHP functions getimagesize() and basename() with WordPress-native wp_getimagesize() and wp_basename().
+  * Fix: Replace loose comparisons (==) with strict comparisons (===), add true to in_array(), and cast dimensions to (int).
+  * Fix: Add safety checks for get_attached_file(), $original_size, and $image_data to prevent PHP 8.0+ TypeError and warnings when physical files are missing or corrupted.
+  * Fix: Convert file extensions to lowercase (strtolower) before validation to correctly process uppercase extensions (e.g., .JPG).
+  * Fix: Separate original $image_path and target $target_path variables to avoid mutating the path string during custom array size processing.
+  * Security/Fix: Add preg_quote() to the regular expression for preg_replace to safely handle file extensions during path generation.
+  * Fix: Ensure image_make_intermediate_size() always uses the original attached file as the source instead of the non-existent target path.
+  * Fix: Add a physical file_exists() check for standard named sizes to force on-the-fly regeneration if the physical file was deleted from the disk but the database metadata still exists.
+
 ### 2.27.6
 * Update packages
 * Update Cyr to Lat Enhanced MU plugin

--- a/wp-content/mu-plugins/otf_regen_thumbs.php
+++ b/wp-content/mu-plugins/otf_regen_thumbs.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/gambitph/WP-OTF-Regenerate-Thumbnails
  * Description: Automatically regenerates your thumbnails on the fly (OTF) after changing the thumbnail sizes or switching themes.
  * Author: Benjamin Intal - Gambit Technologies Inc
- * Version: 0.3.2 (fixed by iDeus)
+ * Version: 0.4 (forked by iDeus)
  * Author URI: http://gambit.ph
  */
 
@@ -17,176 +17,210 @@
  * @see https://wordpress.stackexchange.com/questions/53344/how-to-generate-thumbnails-when-needed-only/124790#124790
  * @see http://codex.wordpress.org/Function_Reference/get_intermediate_image_sizes
  */
-if ( ! function_exists( 'gambit_otf_regen_thumbs_media_downsize' ) ) {
 
+if ( ! function_exists( 'gambit_otf_regen_thumbs_media_downsize' ) ) {
 	/**
 	 * The downsizer. This only does something if the existing image size doesn't exist yet.
 	 *
-	 * @param $out boolean false
-	 * @param $id int Attachment ID
-	 * @param $size mixed The size name, or an array containing the width & height
-	 * @return  mixed False if the custom downsize failed, or an array of the image if successful
+	 * @param bool  $out  boolean false.
+	 * @param int   $id   Attachment ID.
+	 * @param mixed $size The size name, or an array containing the width & height.
+	 * @return mixed False if the custom downsize failed, or an array of the image if successful.
 	 */
 	function gambit_otf_regen_thumbs_media_downsize( $out, $id, $size ) {
 
 		// Gather all the different image sizes of WP (thumbnail, medium, large) and,
 		// all the theme/plugin-introduced sizes.
 		global $_gambit_otf_regen_thumbs_all_image_sizes;
+
 		if ( ! isset( $_gambit_otf_regen_thumbs_all_image_sizes ) ) {
 			global $_wp_additional_image_sizes;
 
 			$_gambit_otf_regen_thumbs_all_image_sizes = array();
-			$interimSizes = get_intermediate_image_sizes();
+			$interim_sizes                            = get_intermediate_image_sizes();
 
-			foreach ( $interimSizes as $sizeName ) {
-				if ( in_array( $sizeName, array( 'thumbnail', 'medium', 'large' ) ) ) {
-					$_gambit_otf_regen_thumbs_all_image_sizes[ $sizeName ]['width']  = get_option( $sizeName . '_size_w' );
-					$_gambit_otf_regen_thumbs_all_image_sizes[ $sizeName ]['height'] = get_option( $sizeName . '_size_h' );
-					$_gambit_otf_regen_thumbs_all_image_sizes[ $sizeName ]['crop']   = (bool) get_option( $sizeName . '_crop' );
-				} elseif ( isset( $_wp_additional_image_sizes[ $sizeName ] ) ) {
-					$_gambit_otf_regen_thumbs_all_image_sizes[ $sizeName ] = $_wp_additional_image_sizes[ $sizeName ];
+			foreach ( $interim_sizes as $size_name ) {
+				if ( in_array( $size_name, array( 'thumbnail', 'medium', 'large' ), true ) ) {
+					$_gambit_otf_regen_thumbs_all_image_sizes[ $size_name ]['width']  = get_option( $size_name . '_size_w' );
+					$_gambit_otf_regen_thumbs_all_image_sizes[ $size_name ]['height'] = get_option( $size_name . '_size_h' );
+					$_gambit_otf_regen_thumbs_all_image_sizes[ $size_name ]['crop']   = (bool) get_option( $size_name . '_crop' );
+				} elseif ( isset( $_wp_additional_image_sizes[ $size_name ] ) ) {
+					$_gambit_otf_regen_thumbs_all_image_sizes[ $size_name ] = $_wp_additional_image_sizes[ $size_name ];
 				}
 			}
 		}
 
-		// This now contains all the data that we have for all the image sizes
-		$allSizes = $_gambit_otf_regen_thumbs_all_image_sizes;
+		// This now contains all the data that we have for all the image sizes.
+		$all_sizes = $_gambit_otf_regen_thumbs_all_image_sizes;
 
-		// If image size exists let WP serve it like normally
-		$imagedata = wp_get_attachment_metadata( $id );
+		// If image size exists let WP serve it like normally.
+		$image_data = wp_get_attachment_metadata( $id );
 
-		// Image attachment doesn't exist
-		if ( ! is_array( $imagedata ) ) {
+		// Image attachment doesn't exist.
+		if ( ! is_array( $image_data ) ) {
 			return false;
 		}
 
-		// If the size given is a string / a name of a size
+		// If the size given is a string / a name of a size.
 		if ( is_string( $size ) ) {
 
-			// If WP doesn't know about the image size name, then we can't really do any resizing of our own
-			if ( empty( $allSizes[ $size ] ) ) {
+			// If WP doesn't know about the image size name, then we can't really do any resizing of our own.
+			if ( empty( $all_sizes[ $size ] ) ) {
 				return false;
 			}
 
-			// If the size has already been previously created, use it
-			if ( ! empty( $imagedata['sizes'][ $size ] ) && ! empty( $allSizes[ $size ] ) ) {
-				// But only if the size remained the same
-				if ( $allSizes[ $size ]['width'] == $imagedata['sizes'][ $size ]['width']
-				&& $allSizes[ $size ]['height'] == $imagedata['sizes'][ $size ]['height'] ) {
+			// If the size has already been previously created, use it.
+			if ( ! empty( $image_data['sizes'][ $size ] ) && ! empty( $all_sizes[ $size ] ) ) {
+
+				// Verify if the file ACTUALLY exists on disk to cover physical deletions.
+				$attached_file = get_attached_file( $id );
+
+				// Prevent TypeError in PHP 8+ if the original file is missing.
+				if ( ! $attached_file ) {
 					return false;
 				}
 
-				// Or if the size is different and we found out before that the size really was different
-				if ( ! empty( $imagedata['sizes'][ $size ][ 'width_query' ] )
-				&& ! empty( $imagedata['sizes'][ $size ]['height_query'] ) ) {
-					if ( $imagedata['sizes'][ $size ]['width_query'] == $allSizes[ $size ]['width']
-					&& $imagedata['sizes'][ $size ]['height_query'] == $allSizes[ $size ]['height'] ) {
+				$file_path = dirname( $attached_file ) . '/' . $image_data['sizes'][ $size ]['file'];
+
+				// Only skip regeneration if the file is physically present.
+				if ( file_exists( $file_path ) ) {
+					// But only if the size remained the same.
+					if ( (int) $all_sizes[ $size ]['width'] === (int) $image_data['sizes'][ $size ]['width']
+						&& (int) $all_sizes[ $size ]['height'] === (int) $image_data['sizes'][ $size ]['height']
+					) {
 						return false;
+					}
+
+					// Or if the size is different and we found out before that the size really was different.
+					if ( ! empty( $image_data['sizes'][ $size ]['width_query'] )
+						&& ! empty( $image_data['sizes'][ $size ]['height_query'] )
+					) {
+						if ( (int) $image_data['sizes'][ $size ]['width_query'] === (int) $all_sizes[ $size ]['width']
+							&& (int) $image_data['sizes'][ $size ]['height_query'] === (int) $all_sizes[ $size ]['height']
+						) {
+							return false;
+						}
 					}
 				}
 			}
 
-			// Resize the image
+			// Resize the image.
 			$resized = image_make_intermediate_size(
 				get_attached_file( $id ),
-				$allSizes[ $size ]['width'],
-				$allSizes[ $size ]['height'],
-				$allSizes[ $size ]['crop']
+				$all_sizes[ $size ]['width'],
+				$all_sizes[ $size ]['height'],
+				$all_sizes[ $size ]['crop']
 			);
 
-			// Resize somehow failed
+			// Resize somehow failed.
 			if ( ! $resized ) {
 				return false;
 			}
 
-			// Save the new size in WP
-			$imagedata['sizes'][ $size ] = $resized;
+			// Save the new size in WP.
+			$image_data['sizes'][ $size ] = $resized;
 
-			// Save some additional info so that we'll know next time whether we've resized this before
-			$imagedata['sizes'][ $size ]['width_query']  = $allSizes[ $size ]['width'];
-			$imagedata['sizes'][ $size ]['height_query'] = $allSizes[ $size ]['height'];
+			// Save some additional info so that we'll know next time whether we've resized this before.
+			$image_data['sizes'][ $size ]['width_query']  = $all_sizes[ $size ]['width'];
+			$image_data['sizes'][ $size ]['height_query'] = $all_sizes[ $size ]['height'];
 
-			wp_update_attachment_metadata( $id, $imagedata );
+			wp_update_attachment_metadata( $id, $image_data );
 
-			// Serve the resized image
+			// Serve the resized image.
 			$att_url = wp_get_attachment_url( $id );
 			return array( dirname( $att_url ) . '/' . $resized['file'], $resized['width'], $resized['height'], true );
 
-
-		// If the size given is a custom array size
+		// If the size given is a custom array size.
 		} elseif ( is_array( $size ) ) {
-			$imagePath  = get_attached_file( $id );
+			$image_path = get_attached_file( $id );
 
-			$crop       = array_key_exists(2, $size) ? $size[2] : true;
-			$new_width  = $size[0];
-			$new_height = $size[1];
-
-			// If crop is false, calculate new image dimensions
-			if ( ! $crop ) {
-				if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
-					add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
-					$trueData = wp_get_attachment_image_src( $id, 'large' );
-					remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
-				} else {
-					$trueData = wp_get_attachment_image_src( $id, 'large' );
-				}
-
-				if ( $trueData[1] > $trueData[2] ) {
-					// Width > height
-					$ratio      = $trueData[1] / $size[0];
-					$new_height = round( $trueData[2] / $ratio );
-					$new_width  = $size[0];
-				} else {
-					// Height > width
-					$ratio      = $trueData[2] / $size[1];
-					$new_height = $size[1];
-					$new_width  = round( $trueData[1] / $ratio );
-				}
-			}
-
-			// This would be the path of our resized image if the dimensions existed
-			$imageExt = pathinfo( $imagePath, PATHINFO_EXTENSION );
-
-			// Check if image
-			if ( ! in_array( $imageExt, array( 'jpg', 'jpeg', 'png', 'gif', 'webp' ) ) ) {
+			// Prevent TypeError in PHP 8+ if the original file is missing.
+			if ( ! $image_path ) {
 				return false;
 			}
 
-			$original_size = getimagesize( $imagePath );
-			$sizes         = image_resize_dimensions( $original_size[0], $original_size[1], $size[0], $size[1], true );
-			if ( empty( $sizes ) ) {
-				$imagePath = preg_replace( '/^(.*)\.' . $imageExt . '$/', sprintf( '$1-%sx%s.%s', $new_width, $new_height, $imageExt ) , $imagePath );
-			} else {
-				$imagePath = preg_replace( '/^(.*)\.' . $imageExt . '$/', sprintf( '$1-%sx%s.%s', $sizes[4], $sizes[5], $imageExt ) , $imagePath );
+			$crop       = array_key_exists( 2, $size ) ? $size[2] : true;
+			$new_width  = $size[0];
+			$new_height = $size[1];
+
+			// If crop is false, calculate new image dimensions.
+			if ( ! $crop ) {
+				if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
+					add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+					$true_data = wp_get_attachment_image_src( $id, 'large' );
+					remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+				} else {
+					$true_data = wp_get_attachment_image_src( $id, 'large' );
+				}
+
+				if ( $true_data[1] > $true_data[2] ) {
+					// Width > height.
+					$ratio      = $true_data[1] / $size[0];
+					$new_height = (int) round( $true_data[2] / $ratio );
+					$new_width  = $size[0];
+				} else {
+					// Height > width.
+					$ratio      = $true_data[2] / $size[1];
+					$new_height = $size[1];
+					$new_width  = (int) round( $true_data[1] / $ratio );
+				}
 			}
+
+			// Get the extension for strict validation, converted to lowercase to avoid .JPG failing.
+			$ext_regex = pathinfo( $image_path, PATHINFO_EXTENSION );
+			$image_ext = strtolower( $ext_regex );
+
+			// Check if image. Added 'avif' for modern WP support.
+			if ( ! in_array( $image_ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif' ), true ) ) {
+				return false;
+			}
+
+			$original_size = wp_getimagesize( $image_path );
+
+			// Bail if original size can't be found.
+			if ( empty( $original_size ) ) {
+				return false;
+			}
+
+			$sizes = image_resize_dimensions( $original_size[0], $original_size[1], $size[0], $size[1], true );
+
+			// Calculate target path separately to not mutate original $image_path string.
+			if ( empty( $sizes ) ) {
+				$target_path = preg_replace( '/^(.*)\.' . preg_quote( $ext_regex, '/' ) . '$/', sprintf( '$1-%sx%s.%s', $new_width, $new_height, $ext_regex ), $image_path );
+			} else {
+				$target_path = preg_replace( '/^(.*)\.' . preg_quote( $ext_regex, '/' ) . '$/', sprintf( '$1-%sx%s.%s', $sizes[4], $sizes[5], $ext_regex ), $image_path );
+			}
+
 			$att_url = wp_get_attachment_url( $id );
 
-			// If it already exists, serve it
-			if ( file_exists( $imagePath ) ) {
-				return array( dirname( $att_url ) . '/' . basename( $imagePath ), $new_width, $new_height, $crop );
+			// If it already exists, serve it.
+			if ( file_exists( $target_path ) ) {
+				return array( dirname( $att_url ) . '/' . wp_basename( $target_path ), $new_width, $new_height, $crop );
 			}
 
-			// If not, resize the image...
+			// If not, create a resized copy from the original image.
 			$resized = image_make_intermediate_size(
-				get_attached_file( $id ),
+				$image_path,
 				$size[0],
 				$size[1],
 				$crop
 			);
 
-			// Resize somehow failed
+			// Resize somehow failed.
 			if ( ! $resized ) {
 				return false;
 			}
 
-			// Get attachment meta so we can add new size
-			$imagedata = wp_get_attachment_metadata( $id );
+			// Get attachment meta so we can add new size.
+			$image_data = wp_get_attachment_metadata( $id );
 
-			// Save the new size in WP so that it can also perform actions on it
-			$imagedata['sizes'][ $size[0] . 'x' . $size[1] ] = $resized;
-			wp_update_attachment_metadata( $id, $imagedata );
+			// Save the new size in WP so that it can also perform actions on it.
+			if ( is_array( $image_data ) ) {
+				$image_data['sizes'][ $size[0] . 'x' . $size[1] ] = $resized;
+				wp_update_attachment_metadata( $id, $image_data );
+			}
 
-			// Then serve it
+			// Then serve it.
 			return array( dirname( $att_url ) . '/' . $resized['file'], $resized['width'], $resized['height'], $crop );
 		}
 

--- a/wp-content/mu-plugins/wp-framework.php
+++ b/wp-content/mu-plugins/wp-framework.php
@@ -4,7 +4,7 @@
  * Plugin URI:  https://github.com/ideus-team/wp-framework
  * Description: Functions for WP-framework
  * Author:      iDeus
- * Version:     2.27.6
+ * Version:     2.28.0
  * Author URI:  https://ideus.biz
  *
  * @package WP-framework

--- a/wp-content/themes/theme/dev/package-lock.json
+++ b/wp-content/themes/theme/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ideus-html-framework",
-	"version": "2.27.6",
+	"version": "2.28.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ideus-html-framework",
-			"version": "2.27.6",
+			"version": "2.28.0",
 			"devDependencies": {
 				"@babel/core": "7.29.7",
 				"@babel/preset-env": "7.29.7",
@@ -4415,9 +4415,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.364",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
-			"integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+			"version": "1.5.365",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.365.tgz",
+			"integrity": "sha512-xfip4u1QF1s+URFqpA6N+OeFpDGpN7VJz1f3MO3bVL0QYBjpGiZ5/Of7kugvM+o8TTqmanUlviHN3c8M9vYWCw==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -8844,9 +8844,9 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.46",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-			"integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+			"version": "2.0.47",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+			"integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/wp-content/themes/theme/dev/package.json
+++ b/wp-content/themes/theme/dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ideus-html-framework",
-	"version": "2.27.6",
+	"version": "2.28.0",
 	"description": "Our HTML5 boilerplate",
 	"devDependencies": {
 		"@babel/core": "7.29.7",

--- a/wp-content/themes/theme/style.css
+++ b/wp-content/themes/theme/style.css
@@ -4,6 +4,6 @@
  * Author:      iDeus
  * Author URI:  https://ideus.biz/
  * Description: %ThemeDescription%
- * Version:     2.27.6
+ * Version:     2.28.0
  * Text Domain: nc_theme
  */


### PR DESCRIPTION
* Update OTF Regenerate Thumbnails plugin:
  * Refactor: Enforce strict WordPress Coding Standards (WPCS), including tab indentation, proper spacing, and separating the plugin header from the DocBlock.
  * Style: Update variable naming conventions from camelCase to snake_case (e.g., $imagePath to $image_path).
  * Enhancement: Add avif to the list of supported image extensions for modern WordPress compatibility.
  * Refactor: Replace native PHP functions getimagesize() and basename() with WordPress-native wp_getimagesize() and wp_basename().
  * Fix: Replace loose comparisons (==) with strict comparisons (===), add true to in_array(), and cast dimensions to (int).
  * Fix: Add safety checks for get_attached_file(), $original_size, and $image_data to prevent PHP 8.0+ TypeError and warnings when physical files are missing or corrupted.
  * Fix: Convert file extensions to lowercase (strtolower) before validation to correctly process uppercase extensions (e.g., .JPG).
  * Fix: Separate original $image_path and target $target_path variables to avoid mutating the path string during custom array size processing.
  * Security/Fix: Add preg_quote() to the regular expression for preg_replace to safely handle file extensions during path generation.
  * Fix: Ensure image_make_intermediate_size() always uses the original attached file as the source instead of the non-existent target path.
  * Fix: Add a physical file_exists() check for standard named sizes to force on-the-fly regeneration if the physical file was deleted from the disk but the database metadata still exists.